### PR TITLE
Improvements for Darwin logical cores and sysctl logical/physical order

### DIFF
--- a/system-cores.el
+++ b/system-cores.el
@@ -316,9 +316,9 @@ system's sysctl output and modify this function accordingly!]
               #'(lambda (s) (split-string s ": " t))
               (process-lines "sysctl" "hw.physicalcpu" "hw.logicalcpu"))))
   `((logical .
-             ,(string-to-number (cadr (assoc "hw.physicalcpu" cpuinfo))))
+             ,(string-to-number (cadr (assoc "hw.logicalcpu" cpuinfo))))
     (physical .
-              ,(string-to-number (cadr (assoc "hw.logicalcpu" cpuinfo)))))))
+              ,(string-to-number (cadr (assoc "hw.physicalcpu" cpuinfo)))))))
 
 (provide 'system-cores)
 

--- a/system-cores.el
+++ b/system-cores.el
@@ -273,8 +273,9 @@ physical processors, listed in the output of the Apple System
 Profiler.
 
   The logical core count is obtained from the value listed for
-the key \"Total Number of Cores\"; the count of physical cores is
-obtained from the value listed for the key \"Number of
+the key \"Total Number of Cores\" and will be doubled if
+\"Hyper-Threading Technology: Enabled\"; the count of physical
+cores is obtained from the value listed for the key \"Number of
 Processors\".
 
   This function is a `system-cores' delegate."
@@ -288,7 +289,10 @@ Processors\".
                               (process-lines "system_profiler"
                                              "SPHardwareDataType"))))))
     `((logical .
-               ,(string-to-number (cadr (assoc "Total Number of Cores" cpuinfo))))
+               ,(let ((ht (string-equal "Enabled"
+                                        (car (last (assoc "Hyper-Threading Technology" cpuinfo))))))
+                  (* (if ht 2 1)
+                     (string-to-number (cadr (assoc "Total Number of Cores" cpuinfo))))))
       (physical .
                 ,(string-to-number (cadr (assoc "Number of Processors" cpuinfo)))))))
 


### PR DESCRIPTION
Nice library. Just the functionality I needed, thanks.

I made a few improvements:
* The logical Darwin cores are double if Hyper-Threading is enabled (it isn't doubled by `system_profiler` automatically like `sysctl` does)
* Fixed logical/physical order for `system-cores-sysctl`