### PR TITLE
Update to support Macs running Big Sur on an M1 chip.

### DIFF
--- a/system-cores.el
+++ b/system-cores.el
@@ -294,7 +294,9 @@ Processors\".
                   (* (if ht 2 1)
                      (string-to-number (cadr (assoc "Total Number of Cores" cpuinfo))))))
       (physical .
-                ,(string-to-number (cadr (assoc "Number of Processors" cpuinfo)))))))
+                ,(cond ((cadr (assoc "Number of Processors" cpuinfo))
+                        (string-to-number (cadr (assoc "Number of Processors" cpuinfo))))
+                       (t (string-to-number (cadr (assoc "Total Number of Cores" cpuinfo)))))))))    
 
 (defun system-cores-sysctl ()
   "Return the number of logical cores, and the number of


### PR DESCRIPTION
Thanks for providing system-cores.el.  It's very handy to 
have a cross-platform method to get that information.

I have a M1 based Mac with Big Sur.  I don't know if it is related 
to Big Sur or to the M1 but the output from 
`  system_profiler SPHardwareDataType`
has changed and `system-cores-profiler` no longer works. 
  
This fix will look for _"Number of Processors"_ in the output.  If
found it retains the previous behavior and use that as the number 
of physical CPUs.  If not it will use _"Total Number of Cores"_ for
 the number of physical CPUs.
 