### PR TITLE
Update system-cores.el

### DIFF
--- a/system-cores.el
+++ b/system-cores.el
@@ -263,9 +263,9 @@ obtained from the value listed for the key
                 "wmic" "cpu" "get" "NumberOfCores,NumberOfLogicalProcessors"
                 "/format:List")))))
     `((logical .
-               ,(string-to-number (cadr (assoc "NumberOfCores" cpuinfo))))
+               ,(string-to-number (cadr (assoc "NumberOfLogicalProcessors" cpuinfo))))
       (physical .
-                ,(string-to-number (cadr (assoc "NumberOfLogicalProcessors" cpuinfo)))))))
+                ,(string-to-number (cadr (assoc "NumberOfCores" cpuinfo)))))))
 
 (defun system-cores-profiler ()
   "Return the number of logical cores, and the number of


### PR DESCRIPTION
fix error in getting cores counts on Windows OS by swapping the string literals